### PR TITLE
fix: client side error on availability page

### DIFF
--- a/lib/session.ts
+++ b/lib/session.ts
@@ -22,5 +22,5 @@ export async function getSession(
 export async function getCurrentUser(...args: GetSessionArgs) {
   const session = await getSession(...args);
 
-  return session.user;
+  return session?.user;
 }


### PR DESCRIPTION
When someone visits the availability link that was shared with them, they were greeted with a client side error. This PR fixes that error.