### PR TITLE
test: add end to end tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,9 @@ STRIPE_PREMIUM_MONTHLY_PLAN_ID=
 # -----------------------------------------------------------------------------
 URL=$NEXTAUTH_URL
 NEXT_PUBLIC_URL=$NEXTAUTH_URL
+
+# -----------------------------------------------------------------------------
+# End to end tests (Playwright)
+# Note: This should be set in GitHub, rather than Vercel
+# -----------------------------------------------------------------------------
+E2E_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -33,9 +33,3 @@ STRIPE_PREMIUM_MONTHLY_PLAN_ID=
 # -----------------------------------------------------------------------------
 URL=$NEXTAUTH_URL
 NEXT_PUBLIC_URL=$NEXTAUTH_URL
-
-# -----------------------------------------------------------------------------
-# End to end tests (Playwright)
-# Note: This should be set in GitHub, rather than Vercel
-# -----------------------------------------------------------------------------
-E2E_TOKEN=

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   e2e:
-    timeout-minutes: 60
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     if: github.event.deployment_status.state == 'success'
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,5 +23,5 @@ jobs:
       - name: Run Playwright tests
         run: pnpm test:e2e
         env:
-          E2E_TOKEN: ${{ secrets.E2E_TOKEN }}
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.target_url }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,27 @@
+name: ci
+
+on:
+  deployment_status:
+
+jobs:
+  e2e:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    if: github.event.deployment_status.state == 'success'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "18.x"
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 7
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+      - name: Install Playwright
+        run: pnpm test:e2e:install
+      - name: Run Playwright tests
+        run: pnpm test:e2e
+        env:
+          E2E_TOKEN: ${{ secrets.E2E_TOKEN }}
+          PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.target_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 
 # testing
 coverage
+storageState.json
 
 # next.js
 .next/

--- a/components/BookingItem.tsx
+++ b/components/BookingItem.tsx
@@ -9,7 +9,7 @@ interface BookingItemProps {
 
 export function BookingItem({ booking }: BookingItemProps) {
   return (
-    <div className="flex items-center justify-between p-4">
+    <li className="flex items-center justify-between p-4">
       <div className="grid gap-1">
         <p className="font-semibold">{booking.name}</p>
         <p className="text-sm text-zinc-600 dark:text-zinc-400">
@@ -18,7 +18,7 @@ export function BookingItem({ booking }: BookingItemProps) {
         </p>
       </div>
       <BookingDeleteButton bookingId={booking.id} />
-    </div>
+    </li>
   );
 }
 BookingItem.Skeleton = function HomeItemSkeleton() {

--- a/components/BookingsList.tsx
+++ b/components/BookingsList.tsx
@@ -13,11 +13,11 @@ export async function BookingsList({ home }: BookingsListProps) {
   const bookings = await findBookingsByHomeId(home.id);
 
   return bookings?.length ? (
-    <div className="divide-y divide-zinc-400/20 rounded-md ring-1 ring-zinc-400/20 ">
+    <ul className="divide-y divide-zinc-400/20 rounded-md ring-1 ring-zinc-400/20 ">
       {bookings.map((booking) => (
         <BookingItem key={booking.id} booking={booking} />
       ))}
-    </div>
+    </ul>
   ) : (
     <EmptyPlaceholder>
       <EmptyPlaceholder.Title>No bookings yet</EmptyPlaceholder.Title>

--- a/components/HomeCreateButton.tsx
+++ b/components/HomeCreateButton.tsx
@@ -53,7 +53,7 @@ export function HomeCreateButton({
       setIsSaving(true);
 
       const res = await superagent.post(`/api/homes`).send(data);
-      const { id } = res.body as Pick<Home, "id">;
+      const { id } = res.body as Home;
 
       router.push(`/home/${id}`);
       router.refresh();

--- a/components/HomeItem.tsx
+++ b/components/HomeItem.tsx
@@ -9,19 +9,18 @@ interface HomeItemProps {
 
 export function HomeItem({ home }: HomeItemProps) {
   return (
-    <Link
-      className="flex items-center justify-between rounded-md p-4 shadow-md ring-1 ring-zinc-400/20 transition-all hover:shadow-lg"
-      href={`/home/${home.id}`}
-    >
-      <div className="grid gap-1">
-        <h2 className="font-semibold">{home.name}</h2>
-        <div>
-          <p className="text-xs text-zinc-600 dark:text-zinc-400">
-            Created on {formatDate(home.createdAt?.toDateString())}
-          </p>
+    <li className="flex items-center justify-between rounded-md shadow-md ring-1 ring-zinc-400/20 transition-all hover:shadow-lg">
+      <Link className="flex-auto p-4" href={`/home/${home.id}`}>
+        <div className="grid gap-1">
+          <h2 className="font-semibold">{home.name}</h2>
+          <div>
+            <p className="text-xs text-zinc-600 dark:text-zinc-400">
+              Created on {formatDate(home.createdAt?.toDateString())}
+            </p>
+          </div>
         </div>
-      </div>
-    </Link>
+      </Link>
+    </li>
   );
 }
 

--- a/components/HomesList.tsx
+++ b/components/HomesList.tsx
@@ -11,11 +11,11 @@ export async function HomesList() {
   const homes = await findHomesByUserId(user!.id);
 
   return homes?.length ? (
-    <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+    <ul className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
       {homes.map((home) => (
         <HomeItem key={home.id} home={home} />
       ))}
-    </div>
+    </ul>
   ) : (
     <EmptyPlaceholder>
       <EmptyPlaceholder.Title>No vacation homes</EmptyPlaceholder.Title>

--- a/e2e/homes.spec.ts
+++ b/e2e/homes.spec.ts
@@ -18,14 +18,6 @@ test.describe("The dashboard", () => {
 });
 
 test.describe("The dashboard", () => {
-  test.only("should show an empty list of vacation homes", async ({ page }) => {
-    await page.goto("/homes");
-
-    await expect(
-      page.getByText("No vacation homes", { exact: true })
-    ).toBeVisible();
-  });
-
   test("should allow the user to create a new vacation home", async ({
     page,
   }) => {

--- a/e2e/homes.spec.ts
+++ b/e2e/homes.spec.ts
@@ -8,9 +8,7 @@ test.describe("The dashboard", () => {
   // @ts-expect-error
   test.use({ storageState: {} });
 
-  test.only("should redirect to the login page when unauthed", async ({
-    page,
-  }) => {
+  test("should redirect to the login page when unauthed", async ({ page }) => {
     await page.goto("/homes");
 
     await expect(page).toHaveURL("/login");

--- a/e2e/homes.spec.ts
+++ b/e2e/homes.spec.ts
@@ -58,7 +58,7 @@ test.describe("The dashboard", () => {
     await page
       .getByLabel("End date")
       .fill(format(endOfWeek(new Date()), "yyyy-MM-dd"));
-    await page.click("text=Create booking");
+    await page.click("text=Create booking"); // TODO: Replace with `locator.click()`
 
     await expect(booking).toBeVisible();
   });
@@ -66,15 +66,21 @@ test.describe("The dashboard", () => {
   test("should allow the user to delete a booking", async ({ page }) => {
     await page.goto("/homes");
 
-    await page.getByRole("listitem").filter({ hasText: HOME_NAME }).click();
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: HOME_NAME })
+      .first()
+      .click();
 
     await page
       .getByRole("listitem")
       .filter({ hasText: BOOKING_NAME })
-      .getByRole("button")
+      .first()
+      .getByRole("button") // TODO: We should probably be a bit more specific here. Button probably isn't accessible enough.
       .click();
 
     await page
+      .getByRole("dialog", { name: "Are you sure?" })
       .getByRole("button")
       .filter({ hasText: "Delete booking" })
       .click();

--- a/e2e/homes.spec.ts
+++ b/e2e/homes.spec.ts
@@ -1,0 +1,113 @@
+import { endOfWeek, format, startOfWeek } from "date-fns";
+import { expect, test } from "@playwright/test";
+
+const HOME_NAME = "Fanta Sea";
+const BOOKING_NAME = "End to end test";
+
+test.describe("The dashboard", () => {
+  // @ts-expect-error
+  test.use({ storageState: {} });
+
+  test("should redirect to the login page when unauthed", async ({ page }) => {
+    await page.goto("/homes");
+
+    await expect(page).toHaveURL("/login");
+  });
+});
+
+test.describe("The dashboard", () => {
+  test("should show an empty list of vacation homes", async ({ page }) => {
+    await page.goto("/homes");
+
+    await expect(
+      page.getByText("No vacation homes", { exact: true })
+    ).toBeVisible();
+  });
+
+  test("should allow the user to create a new vacation home", async ({
+    page,
+  }) => {
+    await page.goto("/homes");
+
+    await page
+      .getByRole("button")
+      .filter({ hasText: "New vacation home" })
+      .first()
+      .click();
+
+    await page.getByLabel("name").fill(HOME_NAME);
+    await page
+      .getByRole("button")
+      .filter({ hasText: "Create vacation home" })
+      .click();
+
+    await page.waitForURL("/home/**");
+
+    await expect(page.getByText(HOME_NAME, { exact: true })).toBeVisible();
+  });
+
+  test("should allow the user to add a booking to a home", async ({ page }) => {
+    await page.goto("/homes");
+
+    await page.getByRole("listitem").filter({ hasText: HOME_NAME }).click();
+
+    const booking = page
+      .getByRole("listitem")
+      .filter({ hasText: BOOKING_NAME });
+
+    await expect(booking).not.toBeVisible();
+
+    await page.getByRole("button").filter({ hasText: "New booking" }).click();
+
+    await page.getByLabel("name").fill(BOOKING_NAME);
+    await page
+      .getByLabel("Start date")
+      .fill(format(startOfWeek(new Date()), "yyyy-MM-dd"));
+    await page
+      .getByLabel("End date")
+      .fill(format(endOfWeek(new Date()), "yyyy-MM-dd"));
+    await page.click("text=Create booking");
+
+    await expect(booking).toBeVisible();
+  });
+
+  test("should allow the user to delete a booking", async ({ page }) => {
+    await page.goto("/homes");
+
+    await page.getByRole("listitem").filter({ hasText: HOME_NAME }).click();
+
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: BOOKING_NAME })
+      .getByRole("button")
+      .click();
+
+    await page
+      .getByRole("button")
+      .filter({ hasText: "Delete booking" })
+      .click();
+
+    await expect(
+      page.getByRole("listitem").filter({ hasText: BOOKING_NAME })
+    ).not.toBeVisible();
+  });
+
+  test("should allow the user to delete a vacation home", async ({ page }) => {
+    await page.goto("/homes");
+
+    await page.getByRole("listitem").filter({ hasText: HOME_NAME }).click();
+
+    await page.getByRole("button").filter({ hasText: "Settings" }).click();
+
+    await page.getByRole("button").filter({ hasText: "Delete home" }).click();
+
+    await page
+      .getByRole("dialog", { name: "Are you sure?" })
+      .getByRole("button")
+      .filter({ hasText: "Delete home" })
+      .click();
+
+    await expect(page).toHaveURL("/homes");
+    await expect(page.locator(`text=${HOME_NAME}`)).not.toBeVisible();
+  });
+});

--- a/e2e/homes.spec.ts
+++ b/e2e/homes.spec.ts
@@ -8,7 +8,9 @@ test.describe("The dashboard", () => {
   // @ts-expect-error
   test.use({ storageState: {} });
 
-  test("should redirect to the login page when unauthed", async ({ page }) => {
+  test.only("should redirect to the login page when unauthed", async ({
+    page,
+  }) => {
     await page.goto("/homes");
 
     await expect(page).toHaveURL("/login");
@@ -16,7 +18,7 @@ test.describe("The dashboard", () => {
 });
 
 test.describe("The dashboard", () => {
-  test("should show an empty list of vacation homes", async ({ page }) => {
+  test.only("should show an empty list of vacation homes", async ({ page }) => {
     await page.goto("/homes");
 
     await expect(

--- a/e2e/homes.spec.ts
+++ b/e2e/homes.spec.ts
@@ -49,7 +49,11 @@ test.describe("The dashboard", () => {
 
     await expect(booking).not.toBeVisible();
 
-    await page.getByRole("button").filter({ hasText: "New booking" }).click();
+    await page
+      .getByRole("button")
+      .filter({ hasText: "New booking" })
+      .first()
+      .click();
 
     await page.getByLabel("name").fill(BOOKING_NAME);
     await page
@@ -58,7 +62,10 @@ test.describe("The dashboard", () => {
     await page
       .getByLabel("End date")
       .fill(format(endOfWeek(new Date()), "yyyy-MM-dd"));
-    await page.click("text=Create booking"); // TODO: Replace with `locator.click()`
+    await page
+      .getByRole("button")
+      .filter({ hasText: "Create booking" })
+      .click();
 
     await expect(booking).toBeVisible();
   });
@@ -93,7 +100,9 @@ test.describe("The dashboard", () => {
   test("should allow the user to delete a vacation home", async ({ page }) => {
     await page.goto("/homes");
 
-    await page.getByRole("listitem").filter({ hasText: HOME_NAME }).click();
+    const home = page.getByRole("listitem").filter({ hasText: HOME_NAME });
+
+    await home.click();
 
     await page.getByRole("button").filter({ hasText: "Settings" }).click();
 
@@ -106,6 +115,6 @@ test.describe("The dashboard", () => {
       .click();
 
     await expect(page).toHaveURL("/homes");
-    await expect(page.locator(`text=${HOME_NAME}`)).not.toBeVisible();
+    await expect(home).not.toBeVisible();
   });
 });

--- a/e2e/setup/global-setup.ts
+++ b/e2e/setup/global-setup.ts
@@ -21,8 +21,8 @@ export default async function globalSetup(config: FullConfig) {
       value: sessionToken,
       domain: new URL(baseURL!).hostname,
       path: "/",
-      httpOnly: true,
-      sameSite: "Lax",
+      // httpOnly: true,
+      // sameSite: "Lax",
       expires: expires.getTime() / 1000,
     },
   ]);

--- a/e2e/setup/global-setup.ts
+++ b/e2e/setup/global-setup.ts
@@ -1,0 +1,36 @@
+import * as dotenv from "dotenv";
+
+import type { FullConfig } from "@playwright/test";
+import { addMonths } from "date-fns";
+import { chromium } from "@playwright/test";
+
+dotenv.config();
+
+export default async function globalSetup(config: FullConfig) {
+  const { baseURL, storageState } = config.projects[0].use;
+  const sessionToken = process.env.E2E_TOKEN as string;
+
+  const expires = addMonths(new Date(), 1);
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  await page.context().addCookies([
+    {
+      name: "next-auth.session-token",
+      value: sessionToken,
+      domain: new URL(baseURL!).hostname,
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+      expires: expires.getTime() / 1000,
+    },
+  ]);
+
+  await page.context().storageState({
+    // @ts-ignore
+    path: storageState,
+  });
+
+  await browser.close();
+}

--- a/e2e/setup/global-setup.ts
+++ b/e2e/setup/global-setup.ts
@@ -1,21 +1,21 @@
 import * as dotenv from "dotenv";
 
-import type { FullConfig } from "@playwright/test";
 import { chromium } from "@playwright/test";
 import { encode } from "next-auth/jwt";
+import path from "path";
 
 dotenv.config();
 
-export default async function globalSetup(config: FullConfig) {
-  const { storageState } = config.projects[0].use;
+export default async function globalSetup() {
+  const storageState = path.resolve(__dirname, "storageState.json");
   const baseURL =
     process.env.PLAYWRIGHT_TEST_BASE_URL || "http://localhost:3000";
   const domain = new URL(baseURL).hostname;
 
   const secure = domain !== "localhost";
   const sessionToken = await encode({
+    // @ts-ignore
     token: {
-      id: "clbs0af0y0000p2do3lm5kgnr",
       email: "e2e@nielsbik.nl",
     },
     secret: process.env.NEXTAUTH_SECRET!,

--- a/lib/homes.ts
+++ b/lib/homes.ts
@@ -32,11 +32,13 @@ export async function findHomeById(id: Home["id"]) {
 }
 
 export async function findHomeByShareKey(key: ShareKey["id"]) {
-  const { homeId } = await db.shareKey.findUniqueOrThrow({
+  const shareKey = await db.shareKey.findUnique({
     where: { id: key },
   });
 
-  return await findHomeById(homeId);
+  if (!shareKey) return null;
+
+  return await findHomeById(shareKey.homeId);
 }
 
 export async function updateHome(

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test:e2e": "playwright test",
+    "test:e2e:debug": "playwright test --debug",
+    "test:e2e:install": "playwright install --with-deps",
     "lint": "next lint",
     "postinstall": "prisma generate"
   },
@@ -54,6 +57,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.3.0",
     "@commitlint/config-conventional": "^17.3.0",
+    "@playwright/test": "^1.29.0",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/typography": "^0.5.8",
     "@types/lodash": "^4.14.188",
@@ -62,6 +66,7 @@
     "@types/react-dom": "^18.0.7",
     "@types/superagent": "^4.1.15",
     "autoprefixer": "^10.4.0",
+    "dotenv": "^16.0.3",
     "eslint": "^7.32.0",
     "eslint-config-next": "^13.0.5",
     "husky": "^8.0.2",

--- a/pages/api/homes/index.ts
+++ b/pages/api/homes/index.ts
@@ -42,7 +42,7 @@ handler.post(async (req, res) => {
 
   const body = homeCreateSchema.parse(req.body);
 
-  const home = createHome(user!.id, body);
+  const home = await createHome(user!.id, body);
 
   return res.status(201).json(home);
 });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,6 +1,7 @@
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 module.exports = {
   globalSetup: "./e2e/setup/global-setup.ts",
+  timeout: 10 * 1000,
   use: {
     baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || "http://localhost:3000",
     storageState: "./e2e/setup/storageState.json",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,8 @@
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+module.exports = {
+  globalSetup: "./e2e/setup/global-setup.ts",
+  use: {
+    baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || "http://localhost:3000",
+    storageState: "./e2e/setup/storageState.json",
+  },
+};

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,7 +1,7 @@
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 module.exports = {
   globalSetup: "./e2e/setup/global-setup.ts",
-  timeout: 10 * 1000,
+  timeout: 20 * 1000,
   use: {
     baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || "http://localhost:3000",
     storageState: "./e2e/setup/storageState.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ specifiers:
   '@heroicons/react': ^2.0.13
   '@hookform/resolvers': ^2.9.10
   '@next-auth/prisma-adapter': ^1.0.5
+  '@playwright/test': ^1.29.0
   '@prisma/client': ^4.7.0
   '@stripe/react-stripe-js': ^1.15.0
   '@stripe/stripe-js': ^1.44.1
@@ -21,6 +22,7 @@ specifiers:
   autoprefixer: ^10.4.0
   clsx: ^1.2.1
   date-fns: ^2.29.3
+  dotenv: ^16.0.3
   eslint: ^7.32.0
   eslint-config-next: ^13.0.5
   fast-glob: ^3.2.12
@@ -92,6 +94,7 @@ dependencies:
 devDependencies:
   '@commitlint/cli': 17.3.0
   '@commitlint/config-conventional': 17.3.0
+  '@playwright/test': 1.29.0
   '@tailwindcss/forms': 0.5.3_tailwindcss@3.2.4
   '@tailwindcss/typography': 0.5.8_tailwindcss@3.2.4
   '@types/lodash': 4.14.190
@@ -100,6 +103,7 @@ devDependencies:
   '@types/react-dom': 18.0.9
   '@types/superagent': 4.1.16
   autoprefixer: 10.4.13_postcss@8.4.19
+  dotenv: 16.0.3
   eslint: 7.32.0
   eslint-config-next: 13.0.5_77fvizpdb3y4icyeo2mf4eo7em
   husky: 8.0.2
@@ -600,6 +604,15 @@ packages:
       picocolors: 1.0.0
       tiny-glob: 0.2.9
       tslib: 2.4.1
+    dev: true
+
+  /@playwright/test/1.29.0:
+    resolution: {integrity: sha512-gp5PVBenxTJsm2bATWDNc2CCnrL5OaA/MXQdJwwkGQtqTjmY+ZOqAdLqo49O9MLTDh2vYh+tHWDnmFsILnWaeA==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      '@types/node': 17.0.45
+      playwright-core: 1.29.0
     dev: true
 
   /@prisma/client/4.7.0_prisma@4.7.0:
@@ -1548,6 +1561,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       is-obj: 2.0.0
+    dev: true
+
+  /dotenv/16.0.3:
+    resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
+    engines: {node: '>=12'}
     dev: true
 
   /electron-to-chromium/1.4.284:
@@ -3666,6 +3684,12 @@ packages:
   /pify/2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /playwright-core/1.29.0:
+    resolution: {integrity: sha512-pboOm1m0RD6z1GtwAbEH60PYRfF87vKdzOSRw2RyO0Y0a7utrMyWN2Au1ojGvQr4umuBMODkKTv607YIRypDSQ==}
+    engines: {node: '>=14'}
+    hasBin: true
     dev: true
 
   /postcss-import/14.1.0_postcss@8.4.19:


### PR DESCRIPTION
### Progress

- [x] Initial setup
- [x] Verify everything works both locally and against PR's
- [x] ~See if we can move to `strategy: 'database'` in next-auth so mocking a token is easier~ We can't [at the moment](https://next-auth.js.org/tutorials/securing-pages-and-api-routes#nextjs-middleware).
- [x] Round up actual test setup (see below)

#### Tests

- [x] View (empty) dashboard
- [x] Add a home (verify redirect etc)
- [x] Add a booking
- [ ] ~Enable sharing (verify sharing page works)~ I'll do this later
- [ ] ~Disable sharing (verify sharing page no longer works)~ I'll do this later
- [x] Delete the created booking
- [x] Delete the created home

### Related issues

Closes #40.