### PR TITLE
test: dynamic home name in e2e using faker

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,7 +1,8 @@
-import { endOfWeek, format, startOfWeek } from "date-fns";
 import { expect, test } from "@playwright/test";
 
-const HOME_NAME = "Fanta Sea";
+import { faker } from "@faker-js/faker";
+
+const HOME_NAME = `${faker.name.lastName()} Family Home`;
 const BOOKING_NAME = "End to end test";
 
 test.describe("The dashboard", () => {

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import { faker } from "@faker-js/faker";
 
-const HOME_NAME = `${faker.name.lastName()} Family Home`;
+const HOME_NAME = faker.music.songName();
 const BOOKING_NAME = "End to end test";
 
 test.describe("The dashboard", () => {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.3.0",
     "@commitlint/config-conventional": "^17.3.0",
+    "@faker-js/faker": "^7.6.0",
     "@playwright/test": "^1.29.0",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/typography": "^0.5.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.4
 specifiers:
   '@commitlint/cli': ^17.3.0
   '@commitlint/config-conventional': ^17.3.0
+  '@faker-js/faker': ^7.6.0
   '@headlessui/react': ^1.7.4
   '@heroicons/react': ^2.0.13
   '@hookform/resolvers': ^2.9.10
@@ -98,6 +99,7 @@ dependencies:
 devDependencies:
   '@commitlint/cli': 17.3.0
   '@commitlint/config-conventional': 17.3.0
+  '@faker-js/faker': 7.6.0
   '@playwright/test': 1.29.0
   '@tailwindcss/forms': 0.5.3_tailwindcss@3.2.4
   '@tailwindcss/typography': 0.5.8_tailwindcss@3.2.4
@@ -344,6 +346,11 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@faker-js/faker/7.6.0:
+    resolution: {integrity: sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==}
+    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
     dev: true
 
   /@headlessui/react/1.7.4_biqbaboplfbrettd7655fr4n2y:


### PR DESCRIPTION
The e2e user now has premium, so we can use a dynamic home name to make sure concurrent test runs don't interfere with each other. This also renames the test file to a more descriptive name ("smoke").